### PR TITLE
Allow specifying dimension in Mesh.mesh_geometry

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -32,4 +32,4 @@ jobs:
         run: black --diff --color .
 
       - name: Run static analysis with Ruff
-        run: ruff check --format=github --extend-exclude tests .
+        run: ruff check --output-format=github --extend-exclude tests .

--- a/src/stellarmesh/mesh.py
+++ b/src/stellarmesh/mesh.py
@@ -78,6 +78,7 @@ class Mesh:
         geometry: Geometry,
         min_mesh_size: float = 50,
         max_mesh_size: float = 50,
+        dim: int = 2,
     ):
         """Mesh solids with Gmsh.
 
@@ -86,9 +87,9 @@ class Mesh:
 
         Args:
             geometry: Geometry to be meshed.
-            mesh_filename: Optional filename to store .msh file. Defaults to None.
             min_mesh_size: Min mesh element size. Defaults to 50.
             max_mesh_size: Max mesh element size. Defaults to 50.
+            dim: Generate a mesh up to this dimension. Defaults to 2.
         """
         logger.info(f"Meshing solids with mesh size {min_mesh_size}, {max_mesh_size}")
 
@@ -114,7 +115,7 @@ class Mesh:
 
             gmsh.option.set_number("Mesh.MeshSizeMin", min_mesh_size)
             gmsh.option.set_number("Mesh.MeshSizeMax", max_mesh_size)
-            gmsh.model.mesh.generate(2)
+            gmsh.model.mesh.generate(dim)
 
             mesh._save_changes(save_all=True)
             return mesh

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -5,6 +5,7 @@ author: Alex Koen
 
 desc: MOABModel class represents a MOAB model.
 """
+import logging
 import subprocess
 import tempfile
 from dataclasses import dataclass, field
@@ -15,6 +16,8 @@ import pymoab.core
 import pymoab.types
 
 from .mesh import Mesh
+
+logger = logging.getLogger(__name__)
 
 
 class _MOABEntity:
@@ -199,6 +202,11 @@ class MOABModel:
         known_groups: dict[int, np.uint64] = {}
 
         with mesh:
+            # Warn about volume elements being discarded
+            _, element_tags, _ = gmsh.model.mesh.get_elements(3)
+            if element_tags:
+                logger.warning("Discarding volume elements from mesh.")
+
             volume_dimtags = gmsh.model.get_entities(3)
             volume_tags = [v[1] for v in volume_dimtags]
             for i, volume_tag in enumerate(volume_tags):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,17 @@
+import build123d as bd
+import pytest
+import stellarmesh as sm
+
+
+@pytest.fixture
+def geom_bd_sphere():
+    solids = [bd.Solid.make_sphere(10.0)]
+    return sm.Geometry(solids, ["a"])
+
+
+def test_mesh_geometry_2d(geom_bd_sphere):
+    sm.Mesh.mesh_geometry(geom_bd_sphere, 5, 5, dim=2)
+
+
+def test_mesh_geometry_3d(geom_bd_sphere):
+    sm.Mesh.mesh_geometry(geom_bd_sphere, 5, 5, dim=3)


### PR DESCRIPTION
This small change allows the dimension to be specified when meshing a geometry.