### PR TITLE
Refactor and enhance MOAB/DAGMC-related classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Stellarmesh is a Gmsh wrapper and DAGMC geometry creator for fusion neutronics w
 - [x] Imprinting and merging of conformal geometry
 - [x] Mesh refinement
 - [x] Automated testing and integration
-- [ ] Programatic manipulation of .h5m tags e.g. materials
+- [x] Programatic manipulation of .h5m tags e.g. materials
 
 # Contents
 - [Contents](#contents)
@@ -178,10 +178,8 @@ Many thanks to [Erik B. Knudsen](https://github.com/ebknudsen) for his work on r
 | Open-source | ✓ | ✓ | ✓ |   |
 | Surface-sense handling | ✓ | ✓ | <sup>1</sup> | ✓ |
 | Mesh refinement | ✓ |   | ✓ | ✓ |
-| Manipulation of .h5m files | <sup>2</sup> |   | | |
+| Manipulation of .h5m files | ✓ |   | | |
 
 <em>Note: Please file an issue if this table is out-of-date.</em>
 
 <sup>1</sup> In development on a personal branch
-
-<sup>2</sup> In development

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ mesh = sm.Mesh.from_geometry(geometry, min_mesh_size=50, max_mesh_size=50)
 mesh.write("test.msh")
 mesh.render("doc/torus-mesh-reversed.png", rotation_xyz=(90, 0, -90), normals=15)
 
-h5m = sm.MOABModel.from_mesh(mesh)
+h5m = sm.DAGMCModel.from_mesh(mesh)
 h5m.write("dagmc.h5m")
 h5m.write("dagmc.vtk")
 ```

--- a/examples/layered-torus.py
+++ b/examples/layered-torus.py
@@ -16,6 +16,6 @@ mesh = sm.Mesh.from_geometry(geometry, min_mesh_size=50, max_mesh_size=50)
 mesh.write("test.msh")
 mesh.render("doc/torus-mesh-reversed.png", rotation_xyz=(90, 0, -90), normals=15)
 
-h5m = sm.MOABModel.from_mesh(mesh)
+h5m = sm.DAGMCModel.from_mesh(mesh)
 h5m.write("dagmc.h5m")
 h5m.write("dagmc.vtk")

--- a/src/stellarmesh/__init__.py
+++ b/src/stellarmesh/__init__.py
@@ -1,4 +1,4 @@
 """GMSH wrapper and DAGMC geometry creator."""
 from .geometry import Geometry  # noqa: F401
 from .mesh import Mesh  # noqa: F401
-from .moab import MOABModel, DAGMCModel  # noqa: F401
+from .moab import MOABModel, DAGMCModel, DAGMCSurface, DAGMCVolume  # noqa: F401

--- a/src/stellarmesh/__init__.py
+++ b/src/stellarmesh/__init__.py
@@ -1,4 +1,4 @@
 """GMSH wrapper and DAGMC geometry creator."""
 from .geometry import Geometry  # noqa: F401
 from .mesh import Mesh  # noqa: F401
-from .moab import MOABModel, DAGMCModel, DAGMCSurface, DAGMCVolume  # noqa: F401
+from .moab import DAGMCModel, DAGMCSurface, DAGMCVolume, MOABModel  # noqa: F401

--- a/src/stellarmesh/__init__.py
+++ b/src/stellarmesh/__init__.py
@@ -1,4 +1,4 @@
 """GMSH wrapper and DAGMC geometry creator."""
 from .geometry import Geometry  # noqa: F401
 from .mesh import Mesh  # noqa: F401
-from .moab import MOABModel  # noqa: F401
+from .moab import MOABModel, DAGMCModel  # noqa: F401

--- a/src/stellarmesh/geometry.py
+++ b/src/stellarmesh/geometry.py
@@ -179,7 +179,7 @@ class Geometry:
             FutureWarning,
             stacklevel=2,
         )
-        return cls.from_brep(cls, filename, material_names)
+        return cls.from_brep(filename, material_names)
 
     def imprint(self) -> Geometry:
         """Imprint faces of current geometry.

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -276,7 +276,7 @@ class MOABModel:
         Args:
             core_or_file: path-like or Core object.
         """
-        if isinstance(core_or_file, PathLike):
+        if isinstance(core_or_file, (str, os.PathLike)):
             core = pymoab.core.Core()
             core.load_file(str(core_or_file))
         else:

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -256,8 +256,11 @@ class DAGMCVolume(EntitySet):
                 group.remove(self)
 
         if not existing_group:
-            # Create new group, add name/category tags, add entity
+            # Create new group and add entity
             new_group = self.model.create_group(f"mat:{name}")
+            new_group.global_id = (
+                max((g.global_id for g in self.model.groups), default=0) + 1
+            )
             new_group.add(self)
 
 

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -42,6 +42,12 @@ class _DAGMCEntity:
         self.model = model
         self.handle = handle
 
+    def __eq__(self, other):
+        return self.handle == other.handle
+
+    def __hash__(self):
+        return hash(self.handle)
+
 
 class DAGMCSurface(_DAGMCEntity):
     """DAGMC surface entity."""
@@ -103,10 +109,11 @@ class DAGMCVolume(_DAGMCEntity):
                 core.remove_entities(group_handle, [self.handle])
 
         if not existing_group:
-            # Create new set and add name/category tags
-            group_set = core.create_meshset()
-            core.tag_set_data(model.category_tag, group_set, "Group")
-            core.tag_set_data(model.name_tag, group_set, name)
+            # Create new group, add name/category tags, add entity
+            group_handle = core.create_meshset()
+            core.tag_set_data(model.category_tag, group_handle, "Group")
+            core.tag_set_data(model.name_tag, group_handle, name)
+            core.add_entities(group_handle, [self.handle])
 
 
 @dataclass

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -8,6 +8,7 @@ desc: MOABModel class represents a MOAB model.
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 import tempfile
 import warnings
@@ -23,6 +24,9 @@ from pymoab.rng import Range
 from .mesh import Mesh
 
 logger = logging.getLogger(__name__)
+
+# Type for arguments that accept file paths
+PathLike = Union[str, os.PathLike]
 
 
 class EntitySet:
@@ -264,15 +268,15 @@ class MOABModel:
 
     _core: pymoab.core.Core
 
-    def __init__(self, core_or_file: Union[str, pymoab.core.Core]):
+    def __init__(self, core_or_file: Union[PathLike, pymoab.core.Core]):
         """Initialize model from a file or existing pymoab Core object.
 
         Args:
-            core_or_file: Filename or Core object.
+            core_or_file: path-like or Core object.
         """
-        if isinstance(core_or_file, str):
+        if isinstance(core_or_file, PathLike):
             core = pymoab.core.Core()
-            core.load_file(core_or_file)
+            core.load_file(str(core_or_file))
         else:
             core = core_or_file
         self._core = core
@@ -373,7 +377,7 @@ class MOABModel:
             return cls(mesh_file.name)
 
     @classmethod
-    def read_file(cls, h5m_file: str) -> MOABModel:
+    def read_file(cls, h5m_file: PathLike) -> MOABModel:
         """Initialize model from .h5m file.
 
         Args:
@@ -389,13 +393,13 @@ class MOABModel:
         )
         return cls(h5m_file)
 
-    def write(self, filename: str):
+    def write(self, filename: PathLike):
         """Write MOAB model to .h5m, .vtk, or other file.
 
         Args:
             filename: Filename with format-appropriate extension.
         """
-        self._core.write_file(filename)
+        self._core.write_file(str(filename))
 
 
 class DAGMCModel(MOABModel):
@@ -457,8 +461,8 @@ class DAGMCModel(MOABModel):
 
     @staticmethod
     def make_watertight(
-        input_filename: str,
-        output_filename: str,
+        input_filename: PathLike,
+        output_filename: PathLike,
         binary_path: str = "make_watertight",
     ):
         """Make mesh watertight.
@@ -470,7 +474,7 @@ class DAGMCModel(MOABModel):
             "make_watertight".
         """
         subprocess.run(
-            [binary_path, input_filename, "-o", output_filename],
+            [binary_path, str(input_filename), "-o", str(output_filename)],
             check=True,
         )
 

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -26,19 +26,10 @@ logger = logging.getLogger(__name__)
 
 
 class _MOABEntity:
-    _core: pymoab.core.Core
+    model: MOABModel
     handle: np.uint64
 
-    def __init__(self, core: pymoab.core.Core, handle: np.uint64):
-        self._core = core
-        self.handle = handle
-
-
-class _DAGMCEntity:
-    model: DAGMCModel
-    handle: np.uint64
-
-    def __init__(self, model: DAGMCModel, handle: np.uint64):
+    def __init__(self, model: MOABModel, handle: np.uint64):
         self.model = model
         self.handle = handle
 
@@ -49,8 +40,10 @@ class _DAGMCEntity:
         return hash(self.handle)
 
 
-class DAGMCSurface(_DAGMCEntity):
+class DAGMCSurface(_MOABEntity):
     """DAGMC surface entity."""
+
+    model: DAGMCModel
 
     @property
     def adjacent_volumes(self) -> list[DAGMCVolume]:
@@ -68,8 +61,10 @@ class DAGMCSurface(_DAGMCEntity):
         return self.model._core.get_entities_by_type(self.handle, pymoab.types.MBTRI)
 
 
-class DAGMCVolume(_DAGMCEntity):
+class DAGMCVolume(_MOABEntity):
     """DAGMC volume entity."""
+
+    model: DAGMCModel
 
     @property
     def adjacent_surfaces(self) -> list[DAGMCSurface]:
@@ -83,6 +78,7 @@ class DAGMCVolume(_DAGMCEntity):
 
     @property
     def group_name(self) -> str:
+        """Name of the group containing this volume."""
         for (_, group_name), volume_handles in self.model.groups.items():
             if self.handle in volume_handles:
                 return group_name

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -39,6 +39,12 @@ class _MOABEntity:
     def __hash__(self):
         return hash(self.handle)
 
+    @property
+    def id(self):
+        """Global ID"""
+        model = self.model
+        return model._core.tag_get_data(model.id_tag, self.handle, flat=True)[0]
+
 
 class DAGMCSurface(_MOABEntity):
     """DAGMC surface entity."""

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -416,10 +416,11 @@ class DAGMCModel(MOABModel):
         Returns:
             Group object.
         """
-        handle = self._core.create_meshset()
-        self._core.tag_set_data(self.category_tag, handle, "Group")
-        self._core.tag_set_data(self.name_tag, handle, group_name)
-        return DAGMCGroup(self, handle)
+        group = DAGMCGroup(self, self._core.create_meshset())
+        group.geom_dimension = 4
+        group.category = "Group"
+        group.name = group_name
+        return group
 
     def create_volume(self, global_id: Optional[int] = None) -> DAGMCVolume:
         """Create new volume.

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -121,9 +121,12 @@ class _Surface:
 
 
 class MOABModel:
-    """MOAB Model."""
+    """MOAB Model.
 
-    # h5m_filename: str
+    Args:
+        core: Pymoab core.
+    """
+
     _core: pymoab.core.Core
 
     def __init__(self, core: pymoab.core.Core):
@@ -230,13 +233,18 @@ class MOABModel:
 
 
 class DAGMCModel(MOABModel):
+    """DAGMC Model.
+
+    Args:
+        core: Pymoab core.
+    """
     def __init__(self, core: pymoab.core.Core):
         super().__init__(core)
 
     @property
-    def groups(self):
+    def groups(self) -> dict[tuple[np.uint64, str], pymoab.rng.Range]:
         # Determine mapping of (group name, group entity) to volume handles
-        group_handles = self._core.get_entities_by_type_and_tag(
+        group_handles: pymoab.rng.Range = self._core.get_entities_by_type_and_tag(
             self._core.get_root_set(),
             pymoab.types.MBENTITYSET,
             [self.category_tag],
@@ -245,10 +253,10 @@ class DAGMCModel(MOABModel):
         groups = {}
         for group_handle in group_handles:
             # Get list of volume handles
-            volume_handles = self._core.get_entities_by_type_and_tag(
+            volume_handles: pymoab.rng.Range = self._core.get_entities_by_type_and_tag(
                 group_handle, pymoab.types.MBENTITYSET, [self.category_tag], ["Volume"]
             )
-            group_name = self._core.tag_get_data(
+            group_name: str = self._core.tag_get_data(
                 self.name_tag, group_handle, flat=True
             )[0]
             groups[group_handle, group_name] = volume_handles

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -207,6 +207,23 @@ class MOABModel:
         return cls(core)
 
     @classmethod
+    def from_mesh(cls, mesh: Mesh) -> MOABModel:
+        """Create MOAB model from mesh.
+
+        Args:
+            mesh: Mesh from which to build MOAB mesh.
+
+        Returns:
+            Initialize model.
+        """
+        core = pymoab.core.Core()
+        with tempfile.NamedTemporaryFile(suffix=".vtk", delete=True) as mesh_file:
+            with mesh:
+                gmsh.write(mesh_file.name)
+            core.load_file(mesh_file.name)
+        return cls(core)
+
+    @classmethod
     def read_file(cls, h5m_file: str) -> MOABModel:
         """Initialize model from .h5m file.
 
@@ -238,6 +255,7 @@ class DAGMCModel(MOABModel):
     Args:
         core: Pymoab core.
     """
+
     def __init__(self, core: pymoab.core.Core):
         super().__init__(core)
 

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -65,6 +65,7 @@ class EntitySet:
 
     @property
     def category(self) -> str:
+        """Category for entity set."""
         return self._tag_get_data(self.model.category_tag)
 
     @category.setter
@@ -82,6 +83,7 @@ class EntitySet:
 
     @property
     def geom_dimension(self) -> int:
+        """Geometry dimension."""
         return self._tag_get_data(self.model.geom_dimension_tag)
 
     @geom_dimension.setter
@@ -183,7 +185,7 @@ class DAGMCSurface(EntitySet):
 
     @property
     def surf_sense(self) -> list[np.uint64]:
-        """Surface sense data"""
+        """Surface sense data."""
         return self.model._core.tag_get_data(
             self.model.surf_sense_tag, self.handle, flat=True
         )
@@ -410,6 +412,7 @@ class DAGMCModel(MOABModel):
 
         Args:
             group_name: Name assigned to the new group
+
         Returns:
             Group object.
         """
@@ -423,6 +426,7 @@ class DAGMCModel(MOABModel):
 
         Args:
             global_id: Global ID.
+
         Returns:
             Volume object.
         """
@@ -438,6 +442,7 @@ class DAGMCModel(MOABModel):
 
         Args:
             global_id: Global ID.
+
         Returns:
             Surface object.
         """
@@ -479,7 +484,7 @@ class DAGMCModel(MOABModel):
         )
 
     @classmethod
-    def from_mesh(  # noqa: PLR0915
+    def from_mesh(
         cls,
         mesh: Mesh,
     ) -> DAGMCModel:

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -460,7 +460,8 @@ class DAGMCModel(MOABModel):
                 else:
                     group = known_groups[vol_group]
 
-                group.add(volume_set_handle)
+                volume_set = EntitySet(model, volume_set_handle)
+                group.add(volume_set)
 
                 # Add surfaces to MOAB core, respecting surface sense.
                 # Logic: Gmsh meshes volumes in order. When it gets to the first volume,

--- a/src/stellarmesh/moab.py
+++ b/src/stellarmesh/moab.py
@@ -157,10 +157,7 @@ class DAGMCSurface(EntitySet):
     @property
     def forward_volume(self) -> Optional[DAGMCVolume]:
         """Volume with forward sense with respect to the surface."""
-        try:
-            return self.surf_sense[0]
-        except RuntimeError:
-            return None
+        return self.surf_sense[0]
 
     @forward_volume.setter
     def forward_volume(self, volume: DAGMCVolume):
@@ -169,10 +166,7 @@ class DAGMCSurface(EntitySet):
     @property
     def reverse_volume(self) -> Optional[DAGMCVolume]:
         """Volume with reverse sense with respect to the surface."""
-        try:
-            return self.surf_sense[1]
-        except RuntimeError:
-            return None
+        return self.surf_sense[1]
 
     @reverse_volume.setter
     def reverse_volume(self, volume: DAGMCVolume):
@@ -181,9 +175,13 @@ class DAGMCSurface(EntitySet):
     @property
     def surf_sense(self) -> list[Optional[DAGMCVolume]]:
         """Surface sense data."""
-        handles = self.model._core.tag_get_data(
-            self.model.surf_sense_tag, self.handle, flat=True
-        )
+        try:
+            handles = self.model._core.tag_get_data(
+                self.model.surf_sense_tag, self.handle, flat=True
+            )
+        except RuntimeError:
+            return [None, None]
+
         return [
             DAGMCVolume(self.model, handle) if handle != 0 else None
             for handle in handles

--- a/tests/test_moab.py
+++ b/tests/test_moab.py
@@ -55,12 +55,15 @@ def test_triangles(model):
     assert all_tris.contains(surf_tris)
 
 
-def test_group_name(model):
+def test_material(model):
     vol = model.volumes[0]
-    assert vol.group_name == "mat:iron"
+    assert vol.material == "iron"
+    assert "mat:iron" in vol.groups
 
-    vol.group_name = "mat:plastic"
-    assert vol.group_name == "mat:plastic"
+    vol.material = "plastic"
+    assert vol.material == "plastic"
+    assert "mat:iron" not in vol.groups
+    assert "mat:plastic" in vol.groups
 
     group_names = {x[1] for x in model.groups.keys()}
     assert "mat:plastic" in group_names

--- a/tests/test_moab.py
+++ b/tests/test_moab.py
@@ -1,0 +1,66 @@
+import build123d as bd
+import pytest
+import stellarmesh as sm
+from pymoab.rng import Range
+
+
+@pytest.fixture(scope="module")
+def model():
+    solids = [bd.Solid.make_sphere(10.0)]
+    geom = sm.Geometry(solids, ["iron"])
+    mesh = sm.Mesh.from_geometry(geom, max_mesh_size=5, dim=2)
+    return sm.DAGMCModel.from_mesh(mesh)
+
+
+def test_surfaces(model):
+    assert isinstance(model.surfaces, list)
+    assert len(model.surfaces) == 1
+    assert isinstance(model.surfaces[0], sm.DAGMCSurface)
+
+
+def test_volumes(model):
+    assert isinstance(model.volumes, list)
+    assert len(model.volumes) == 1
+    assert isinstance(model.volumes[0], sm.DAGMCVolume)
+
+
+def test_id(model):
+    assert model.surfaces[0].id == 1
+    assert model.volumes[0].id == 0
+
+
+def test_adjacent_surfaces(model):
+    vol = model.volumes[0]
+    surfaces = vol.adjacent_surfaces
+    assert len(surfaces) == 1
+    assert surfaces == [model.surfaces[0]]
+
+
+def test_adjacent_volumes(model):
+    surf = model.surfaces[0]
+    volumes = surf.adjacent_volumes
+    assert len(volumes) == 1
+    assert volumes == [model.volumes[0]]
+
+
+def test_tets(model):
+    assert model.tets.empty()
+
+
+def test_triangles(model):
+    all_tris = model.triangles
+    assert isinstance(all_tris, Range)
+    surf_tris = model.surfaces[0].triangles
+    assert isinstance(surf_tris, Range)
+    assert all_tris.contains(surf_tris)
+
+
+def test_group_name(model):
+    vol = model.volumes[0]
+    assert vol.group_name == "mat:iron"
+
+    vol.group_name = "mat:plastic"
+    assert vol.group_name == "mat:plastic"
+
+    group_names = {x[1] for x in model.groups.keys()}
+    assert "mat:plastic" in group_names

--- a/tests/test_moab.py
+++ b/tests/test_moab.py
@@ -6,21 +6,22 @@ from pymoab.rng import Range
 
 @pytest.fixture(scope="module")
 def model():
-    solids = [bd.Solid.make_sphere(10.0)]
-    geom = sm.Geometry(solids, ["iron"])
+    solid1 = bd.Solid.make_sphere(10.0)
+    solid2 = solid1.faces()[0].thicken(10.0)
+    geom = sm.Geometry([solid1, solid2], ["iron", "iron"])
     mesh = sm.Mesh.from_geometry(geom, max_mesh_size=5, dim=2)
     return sm.DAGMCModel.from_mesh(mesh)
 
 
 def test_surfaces(model):
     assert isinstance(model.surfaces, list)
-    assert len(model.surfaces) == 1
+    assert len(model.surfaces) == 2
     assert isinstance(model.surfaces[0], sm.DAGMCSurface)
 
 
 def test_volumes(model):
     assert isinstance(model.volumes, list)
-    assert len(model.volumes) == 1
+    assert len(model.volumes) == 2
     assert isinstance(model.volumes[0], sm.DAGMCVolume)
 
 
@@ -39,8 +40,10 @@ def test_adjacent_surfaces(model):
 def test_adjacent_volumes(model):
     surf = model.surfaces[0]
     volumes = surf.adjacent_volumes
-    assert len(volumes) == 1
-    assert volumes == [model.volumes[0]]
+    assert len(volumes) == 2
+    assert volumes == [model.volumes[0], model.volumes[1]]
+    assert surf.forward_volume == model.volumes[0]
+    assert surf.reverse_volume == model.volumes[1]
 
 
 def test_tets(model):

--- a/tests/test_moab.py
+++ b/tests/test_moab.py
@@ -58,12 +58,29 @@ def test_triangles(model):
 def test_material(model):
     vol = model.volumes[0]
     assert vol.material == "iron"
-    assert "mat:iron" in vol.groups
+    assert "mat:iron" in {group.name for group in vol.groups}
 
     vol.material = "plastic"
     assert vol.material == "plastic"
-    assert "mat:iron" not in vol.groups
-    assert "mat:plastic" in vol.groups
+    vol_group_names = {group.name for group in vol.groups}
+    assert "mat:iron" not in vol_group_names
+    assert "mat:plastic" in vol_group_names
 
-    group_names = {x[1] for x in model.groups.keys()}
-    assert "mat:plastic" in group_names
+    all_group_names = {group.name for group in model.groups}
+    assert "mat:plastic" in all_group_names
+
+
+def test_group(model):
+    vol = model.volumes[0]
+
+    group = model.create_group("test_group")
+    assert group.name == "test_group"
+
+    group.name = "funny group"
+    assert group.name == "funny group"
+
+    group.add(vol)
+    assert vol in group
+
+    group.remove(vol)
+    assert vol not in group

--- a/tests/test_moab.py
+++ b/tests/test_moab.py
@@ -24,9 +24,9 @@ def test_volumes(model):
     assert isinstance(model.volumes[0], sm.DAGMCVolume)
 
 
-def test_id(model):
-    assert model.surfaces[0].id == 1
-    assert model.volumes[0].id == 0
+def test_global_id(model):
+    assert model.surfaces[0].global_id == 1
+    assert model.volumes[0].global_id == 0
 
 
 def test_adjacent_surfaces(model):
@@ -72,6 +72,7 @@ def test_material(model):
 
 def test_group(model):
     vol = model.volumes[0]
+    surf = model.surfaces[0]
 
     group = model.create_group("test_group")
     assert group.name == "test_group"
@@ -81,6 +82,36 @@ def test_group(model):
 
     group.add(vol)
     assert vol in group
+    assert group.volumes == [vol]
 
     group.remove(vol)
     assert vol not in group
+    assert group.volumes == []
+
+    group.add(surf)
+    assert group.surfaces == [surf]
+    group.remove(surf)
+    assert group.surfaces == []
+
+
+def test_repr(model):
+    surf = model.surfaces[0]
+    repr(surf)
+
+    vol = model.volumes[0]
+    repr(vol)
+
+    group = model.groups[0]
+    repr(group)
+
+
+def test_hash(model):
+    objects = {model.surfaces[0], model.volumes[0]}
+    assert len(objects) == 2
+
+
+def test_moabmodel_from_h5m():
+    solids = [bd.Solid.make_sphere(10.0)]
+    geom = sm.Geometry(solids, ["iron"])
+    mesh = sm.Mesh.from_geometry(geom, max_mesh_size=5, dim=3)
+    model = sm.MOABModel.from_mesh(mesh)


### PR DESCRIPTION
This PR overhauls the classes within moab.py. The class hierarchy now looks as follows:

- `EntitySet`: represents a generic MOAB entity set
- `DAGMCGroup`: represents a DAGMC group, which is just an entity set whose category is "Group". By the DAGMC convention, groups are used to assign material metadata (having a group name that starts with "mat:".
- `DAGMCSurface`: an entity set with category "Surface" that groups together triangles as a faceted surface. This class has several convenience properties that allow one to set the forward/reverse volumes and get a list of triangles.
- `DAGMCVolume`: an entity set with category "Volume" that is related to surfaces by a parent-child relationship. Most importantly, this class has a `material` property that allows you to easily change the material assigned to a volume.
- `MOABModel`: this class holds a generic MOAB mesh. While this could be a 2D surface mesh used for DAGMC, it also can be used for 3D tet meshes.
- `DAGMCModel`: this class is the top-level class representing an .h5m file with a 2D surface mesh that follows the DAGMC conventions.

The class names here meant to draw a separation between things that are generic MOAB constructs (like an `EntitySet`) and things that are specific to the DAGMC file convention (groups, surfaces, volumes, etc.).

## Changing a material

If you want to change the material assigned to a volume, this is now as simple as:
```Python
import stellarmesh as sm

model = sm.DAGMCModel('my_model.h5m')
volume = model.volumes[index]
volume.material = "steel"
```

## Longer-term plan for DAGMC classes

Note that some of the class structure here is inspired/stolen from [pydagmc](https://github.com/svalinn/pydagmc), but at the same time it improves upon it and makes it easier for users to work with .h5m files. My longer-term plan is to try to get the basic structure here merged into pydagmc, have pydagmc be pip-installable, and then stellarmesh can use it as a dependency.