### PR TITLE
Force msh file version to 4.1

### DIFF
--- a/src/stellarmesh/mesh.py
+++ b/src/stellarmesh/mesh.py
@@ -365,6 +365,7 @@ class Mesh:
 
     def _save_changes(self, *, save_all: bool = True):
         gmsh.option.set_number("Mesh.SaveAll", 1 if save_all else 0)
+        gmsh.option.set_number("Mesh.MshFileVersion", 4.1)
         gmsh.write(self._mesh_filename)
 
     def __deepcopy__(self, memo):


### PR DESCRIPTION
Hi Stellarmesh developers!

I have been using stellarmesh recently to generate my DAGMC files and I really enjoy it!

I just wanted to share a tiny modification to enforce the msh file version to 4.1 and avoid crashing if the gmsh configuration is set to 2.0 by default (in the .gmsh-options file for example).

It's possible that you would want to check that the version is correct instead of enforcing it. I just thought it was easier to enforce it anytime we were saving changes. Let me know what you think!